### PR TITLE
Input validation to col_children()

### DIFF
--- a/pytaxize/col.py
+++ b/pytaxize/col.py
@@ -147,6 +147,8 @@ def col_children(name = None, id = None, format = None, start = None, checklist 
         xmlparser = etree.XMLParser()
         tt = etree.fromstring(out.content, xmlparser)
         childtaxa = tt.xpath('//child_taxa//taxon')
+        if len(childtaxa) == 0:
+            sys.exit('Please enter a valid search name')
         outlist = []
         for i in range(len(childtaxa)):
             tt_ = childtaxa[i].getchildren()

--- a/pytaxize/gnr.py
+++ b/pytaxize/gnr.py
@@ -87,6 +87,8 @@ def gnr_resolve(names='Homo sapiens', source=None, format='json', resolve_once='
     data = []
     for each_result in result_json['data']:
         data.append( each_result['results'] if 'results' in each_result else [])
+    if data == [[]]:
+        sys.exit('No matching results to the query')
     return data
     
 if __name__ == "__main__":


### PR DESCRIPTION
ValueError: Shape of passed values is (0, 0), indices imply (3, 0)
It gives the following error when an invalid input is passed.