### PR TITLE
Input validation for itis functions

### DIFF
--- a/pytaxize/itis.py
+++ b/pytaxize/itis.py
@@ -829,6 +829,8 @@ def _itisdf(a, b, matches, colnames, pastens="ax21"):
     for m in matches:
         nodes = a.xpath(m, namespaces=b)
         output.append([x.text for x in nodes])
+    if len(nodes) == 0:
+        sys.exit('Please enter a valid search name')
     df = pd.DataFrame(dict(zip(colnames, output)))
     return df
 


### PR DESCRIPTION
@sckott This change would give a more meaningful error than the current one `ValueError: arrays must all be same length`. The current error is related to pandas.