### PR TITLE
assort key-value pairs into correct DataFrame cols

### DIFF
--- a/pytaxize/itis.py
+++ b/pytaxize/itis.py
@@ -374,10 +374,9 @@ def _itisterms(endpt, args={}, **kwargs):
             output.append(uu)
         else:
             output.append(x)
-
-    df = pd.concat([pd.DataFrame([y.values()[0] for y in x]).transpose() for x in output])
-    df.columns = [x.keys()[0] for x in allnodes[0]]
-    return df
+    
+    df = pd.DataFrame( [ { k: v for d in R for k, v in d.items() } for R in output ] )
+    return df[ [ x.keys()[0] for x in allnodes[0] ] ]
 
 def _get_text_single(x):
     vals = [x.text]


### PR DESCRIPTION
The list comprehension in the function _itisterms() does not correctly sort response key-value pairs into their corresponding columns in the emitted pandas DataFrame. Note the line beginning with tsn 19231 :

![whoops](https://cloud.githubusercontent.com/assets/440383/19546309/6723ea6e-9643-11e6-9e94-e9da6017882f.png)

This commit corrects the problem.