### PR TITLE
repack output into DataFrame in _itisdf

### DIFF
--- a/pytaxize/itis.py
+++ b/pytaxize/itis.py
@@ -896,7 +896,7 @@ def _itisdf(a, b, matches, colnames, pastens="ax21"):
         sys.exit('Please enter a valid search name')
     if not len( output[0] ) == len( output[-1] ) :
         # for some reason, the list of tsn's sometimes begins with a
-        # spurrious None
+        # spurious None
         output[-1] = output[-1][1:]
     df = pd.DataFrame( zip(*output), columns=colnames )[ colnames[::-1] ] 
     return df

--- a/pytaxize/itis.py
+++ b/pytaxize/itis.py
@@ -894,7 +894,11 @@ def _itisdf(a, b, matches, colnames, pastens="ax21"):
         output.append([x.text for x in nodes])
     if len(nodes) == 0:
         sys.exit('Please enter a valid search name')
-    df = pd.DataFrame(dict(zip(colnames, output)))
+    if not len( output[0] ) == len( output[-1] ) :
+        # for some reason, the list of tsn's sometimes begins with a
+        # spurrious None
+        output[-1] = output[-1][1:]
+    df = pd.DataFrame( zip(*output), columns=colnames )[ colnames[::-1] ] 
     return df
 
 def _itisdict(a, b, matches, colnames, pastens="ax21"):


### PR DESCRIPTION
It looks like the structure of output data isn't what was expected by the function. `colnames` is, as expected, a list of column names, while `output` is a list of lists containing the values to be packed into the columns. For some reason, the column 'tsn' (always? often? sometimes?) begins with a spurious `None`, which causes `dict(zip( colnames, output ) )` to fail.