### PR TITLE
Make use of dictionary keys() & values() compatible with Python 3

### DIFF
--- a/pytaxize/itis.py
+++ b/pytaxize/itis.py
@@ -363,20 +363,20 @@ def _itisterms(endpt, args={}, **kwargs):
 
     output = []
     for x in allnodes:
-        kyz = [y.keys()[0] for y in x]
+        kyz = [list(y.keys())[0] for y in x]
         notuniq = set([v for v in kyz if kyz.count(v) > 1])
         if len(notuniq) > 0:
             for z in notuniq:
-                tt = ','.join([ m.values()[0] for m in x if m.keys()[0] == z ])
+                tt = ','.join([ list(m.values())[0] for m in x if list(m.keys())[0] == z ])
                 toadd = { z: tt }
-                uu = [ v for v in x if v.keys()[0] not in z ]
+                uu = [ v for v in x if list(v.keys())[0] not in z ]
                 uu.append(toadd)
             output.append(uu)
         else:
             output.append(x)
     
     df = pd.DataFrame( [ { k: v for d in R for k, v in d.items() } for R in output ] )
-    return df[ [ x.keys()[0] for x in allnodes[0] ] ]
+    return df[ [ list(x.keys())[0] for x in allnodes[0] ] ]
 
 def _get_text_single(x):
     vals = [x.text]

--- a/pytaxize/tax.py
+++ b/pytaxize/tax.py
@@ -179,7 +179,7 @@ def scrapenames(url = None, file = None, text = None, engine = None,
 
   ss = []
   for i in range(len(method.keys())):
-    ss.append(method.keys()[i] in ['url','text'])
+    ss.append(list(method.keys())[i] in ['url','text'])
   out = requests_refactor(base, payload, 'get', content=True)
 
   if(out['status'] != 303):


### PR DESCRIPTION
Indexing dictionary keys, e.g. dict.keys()[0], yields the Python3 error
TypeError: 'dict_keys' object does not support indexing

Using list(dict.keys())[0] works in Py2 & 3
