### PR TITLE
Added GBIF suggestion wrapper, similar in style to the previously ent…

### DIFF
--- a/pytaxize/gbif/__init__.py
+++ b/pytaxize/gbif/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from .parse import parse
+from .suggest import suggest

--- a/pytaxize/gbif/constants.py
+++ b/pytaxize/gbif/constants.py
@@ -1,0 +1,1 @@
+gbif_suggest_url = "https://api.gbif.org/v1/species/suggest"

--- a/pytaxize/gbif/suggest.py
+++ b/pytaxize/gbif/suggest.py
@@ -1,0 +1,58 @@
+import json
+import warnings
+from pytaxize.refactor import Refactor
+from .constants import gbif_suggest_url
+
+"""
+    Get a list of suggested names from GBIF.
+
+    Author Daniel Davies (dd16785@bristol.ac.uk)
+    References https://www.gbif.org/developer/species
+    
+    Usage
+        
+        from pytaxize import gbif
+        response = gbif.suggest(
+            name         :: string,
+            rank         :: string (OPTIONAL),
+            as_dataframe :: bool (OPTIONAL) 
+        )
+"""
+
+
+def suggest(name, rank=None, as_dataframe=False):
+    validate_suggest_inputs(name, rank)
+    request_url = prepare_suggested_names_url(name, rank)
+    response = Refactor(request_url, request="get").json()
+    if as_dataframe:
+        return transform_to_frame_if_available(response)
+    return response
+
+
+def validate_suggest_inputs(name, rank):
+    if name is None or not isinstance(name, str):
+        raise ValueError(
+            "Input name must be a string, describing a single species."
+        )
+
+    if rank is not None and not isinstance(rank, str):
+        raise ValueError(
+            "Input rank must be a string, describing a proposed taxonomic rank."
+        )
+
+
+def prepare_suggested_names_url(name, rank):
+    base_url = gbif_suggest_url + "?q=" + name
+    if rank is not None:
+        base_url += "&rank=" + rank
+    return base_url
+
+
+def transform_to_frame_if_available(response):
+    try:
+        import pandas as pd
+
+        return pd.DataFrame(response)
+    except ImportError:
+        warnings.warn("Pandas library not installed, falling back to json output")
+        return response

--- a/test/test_gbif.py
+++ b/test/test_gbif.py
@@ -1,0 +1,77 @@
+from pytaxize import gbif
+import vcr
+import unittest
+import pytest
+import os
+
+
+def pandas_installed():
+    return False
+    try:
+        import pandas as pd
+
+        return True
+    except:
+        return False
+
+
+class GbifTest(unittest.TestCase):
+    @vcr.use_cassette("test/vcr_cassettes/gbif_suggest.yml")
+    @pytest.mark.skipif(
+        "TRAVIS" in os.environ and os.environ["TRAVIS"] == "true",
+        reason="Skipping this test on Travis CI.",
+    )
+    def test_gbif_suggest_basic_normal_usage(self):
+        respose = gbif.suggest(name="puma con", as_dataframe=False)
+        assert isinstance(respose, list)
+        required_keys_per_record = ["key", "scientificName", "rank"]
+        assert all(
+            map(
+                lambda indiv_record: all(
+                    [key in indiv_record for key in required_keys_per_record]
+                ),
+                respose,
+            )
+        )
+
+    @vcr.use_cassette("test/vcr_cassettes/gbif_suggest.yml")
+    @pytest.mark.skipif(
+        "TRAVIS" in os.environ and os.environ["TRAVIS"] == "true",
+        reason="Skipping this test on Travis CI.",
+    )
+    def test_gbif_suggest_basic_dataframe(self):
+        if pandas_installed():
+            import pandas as pd
+
+            respose = gbif.suggest(name="puma con", as_dataframe=True)
+            assert isinstance(respose, pd.DataFrame)
+            required_keys_per_record = ["key", "scientificName", "rank"]
+
+            assert all(
+                map(lambda indiv_key: indiv_key in respose, required_keys_per_record)
+            )
+
+    @pytest.mark.skipif(
+        "TRAVIS" in os.environ and os.environ["TRAVIS"] == "true",
+        reason="Skipping this test on Travis CI.",
+    )
+    def test_invalid_name_input(self):
+        with pytest.raises(ValueError):
+            gbif.suggest(name=["puma con"])
+
+        with pytest.raises(ValueError):
+            gbif.suggest(name=None)
+
+        with pytest.raises(ValueError):
+            gbif.suggest(name=1, rank="species", as_dataframe=False)
+
+    @pytest.mark.skipif(
+        "TRAVIS" in os.environ and os.environ["TRAVIS"] == "true",
+        reason="Skipping this test on Travis CI.",
+    )
+    def test_invalid_rank_input(self):
+        with pytest.raises(ValueError):
+            gbif.suggest(name="puma con", rank=["species"])
+
+        with pytest.raises(ValueError):
+            gbif.suggest(name="puma con", rank=1)

--- a/test/vcr_cassettes/gbif_suggest.yml
+++ b/test/vcr_cassettes/gbif_suggest.yml
@@ -1,0 +1,124 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://api.gbif.org/v1/species/suggest?q=puma%20con
+  response:
+    body:
+      string: '[{"key":6164622,"kingdom":"Animalia","phylum":"Chordata","order":"Carnivora","family":"Felidae","genus":"Puma","species":"Puma
+        concolor","kingdomKey":1,"phylumKey":44,"classKey":359,"orderKey":732,"familyKey":9703,"genusKey":2435098,"speciesKey":2435099,"parent":"Puma
+        concolor","parentKey":2435099,"scientificName":"Puma concolor puma (Molina,
+        1782)","canonicalName":"Puma concolor puma","rank":"SUBSPECIES","status":"ACCEPTED","higherClassificationMap":{"1":"Animalia","44":"Chordata","359":"Mammalia","732":"Carnivora","9703":"Felidae","2435098":"Puma","2435099":"Puma
+        concolor"},"synonym":false,"class":"Mammalia"},{"key":6164600,"kingdom":"Animalia","phylum":"Chordata","order":"Carnivora","family":"Felidae","genus":"Puma","species":"Puma
+        concolor","kingdomKey":1,"phylumKey":44,"classKey":359,"orderKey":732,"familyKey":9703,"genusKey":2435098,"speciesKey":2435099,"parent":"Puma
+        concolor","parentKey":2435099,"scientificName":"Puma concolor coryi (Bangs,
+        1899)","canonicalName":"Puma concolor coryi","rank":"SUBSPECIES","status":"SYNONYM","higherClassificationMap":{"1":"Animalia","44":"Chordata","359":"Mammalia","732":"Carnivora","9703":"Felidae","2435098":"Puma","2435099":"Puma
+        concolor"},"synonym":true,"class":"Mammalia"},{"key":2435099,"kingdom":"Animalia","phylum":"Chordata","order":"Carnivora","family":"Felidae","genus":"Puma","species":"Puma
+        concolor","kingdomKey":1,"phylumKey":44,"classKey":359,"orderKey":732,"familyKey":9703,"genusKey":2435098,"speciesKey":2435099,"parent":"Puma","parentKey":2435098,"scientificName":"Puma
+        concolor (Linnaeus, 1771)","canonicalName":"Puma concolor","rank":"SPECIES","status":"ACCEPTED","higherClassificationMap":{"1":"Animalia","44":"Chordata","359":"Mammalia","732":"Carnivora","9703":"Felidae","2435098":"Puma"},"synonym":false,"class":"Mammalia"},{"key":6164591,"kingdom":"Animalia","phylum":"Chordata","order":"Carnivora","family":"Felidae","genus":"Puma","species":"Puma
+        concolor","kingdomKey":1,"phylumKey":44,"classKey":359,"orderKey":732,"familyKey":9703,"genusKey":2435098,"speciesKey":2435099,"parent":"Puma
+        concolor","parentKey":2435099,"scientificName":"Puma concolor kaibabensis
+        (Nelson & Goldman, 1931)","canonicalName":"Puma concolor kaibabensis","rank":"SUBSPECIES","status":"SYNONYM","higherClassificationMap":{"1":"Animalia","44":"Chordata","359":"Mammalia","732":"Carnivora","9703":"Felidae","2435098":"Puma","2435099":"Puma
+        concolor"},"synonym":true,"class":"Mammalia"},{"key":9156584,"kingdom":"Animalia","phylum":"Chordata","order":"Carnivora","family":"Felidae","genus":"Puma","species":"Puma
+        concolor","kingdomKey":1,"phylumKey":44,"classKey":359,"orderKey":732,"familyKey":9703,"genusKey":2435098,"speciesKey":2435099,"parent":"Puma
+        concolor","parentKey":2435099,"scientificName":"Puma concolor patagonica (Merriam,
+        1901)","canonicalName":"Puma concolor patagonica","rank":"SUBSPECIES","status":"SYNONYM","higherClassificationMap":{"1":"Animalia","44":"Chordata","359":"Mammalia","732":"Carnivora","9703":"Felidae","2435098":"Puma","2435099":"Puma
+        concolor"},"synonym":true,"class":"Mammalia"},{"key":9045222,"kingdom":"Animalia","phylum":"Chordata","order":"Carnivora","family":"Felidae","genus":"Puma","species":"Puma
+        concolor","kingdomKey":1,"phylumKey":44,"classKey":359,"orderKey":732,"familyKey":9703,"genusKey":2435098,"speciesKey":2435099,"parent":"Puma
+        concolor","parentKey":2435099,"scientificName":"Puma concolor araucanus (Osgood,
+        1943)","canonicalName":"Puma concolor araucanus","rank":"SUBSPECIES","status":"SYNONYM","higherClassificationMap":{"1":"Animalia","44":"Chordata","359":"Mammalia","732":"Carnivora","9703":"Felidae","2435098":"Puma","2435099":"Puma
+        concolor"},"synonym":true,"class":"Mammalia"},{"key":6164624,"kingdom":"Animalia","phylum":"Chordata","order":"Carnivora","family":"Felidae","genus":"Puma","species":"Puma
+        concolor","kingdomKey":1,"phylumKey":44,"classKey":359,"orderKey":732,"familyKey":9703,"genusKey":2435098,"speciesKey":2435099,"parent":"Puma
+        concolor","parentKey":2435099,"scientificName":"Puma concolor costaricensis
+        (Merriam, 1901)","canonicalName":"Puma concolor costaricensis","rank":"SUBSPECIES","status":"ACCEPTED","higherClassificationMap":{"1":"Animalia","44":"Chordata","359":"Mammalia","732":"Carnivora","9703":"Felidae","2435098":"Puma","2435099":"Puma
+        concolor"},"synonym":false,"class":"Mammalia"},{"key":6164603,"kingdom":"Animalia","phylum":"Chordata","order":"Carnivora","family":"Felidae","genus":"Puma","species":"Puma
+        concolor","kingdomKey":1,"phylumKey":44,"classKey":359,"orderKey":732,"familyKey":9703,"genusKey":2435098,"speciesKey":2435099,"parent":"Puma
+        concolor","parentKey":2435099,"scientificName":"Puma concolor missoulensis
+        (Goldman, 1943)","canonicalName":"Puma concolor missoulensis","rank":"SUBSPECIES","status":"SYNONYM","higherClassificationMap":{"1":"Animalia","44":"Chordata","359":"Mammalia","732":"Carnivora","9703":"Felidae","2435098":"Puma","2435099":"Puma
+        concolor"},"synonym":true,"class":"Mammalia"},{"key":6164599,"kingdom":"Animalia","phylum":"Chordata","order":"Carnivora","family":"Felidae","genus":"Puma","species":"Puma
+        concolor","kingdomKey":1,"phylumKey":44,"classKey":359,"orderKey":732,"familyKey":9703,"genusKey":2435098,"speciesKey":2435099,"parent":"Puma
+        concolor","parentKey":2435099,"scientificName":"Puma concolor azteca (Merriam,
+        1901)","canonicalName":"Puma concolor azteca","rank":"SUBSPECIES","status":"SYNONYM","higherClassificationMap":{"1":"Animalia","44":"Chordata","359":"Mammalia","732":"Carnivora","9703":"Felidae","2435098":"Puma","2435099":"Puma
+        concolor"},"synonym":true,"class":"Mammalia"},{"key":8916934,"kingdom":"Animalia","phylum":"Chordata","order":"Carnivora","family":"Felidae","genus":"Puma","species":"Puma
+        concolor","kingdomKey":1,"phylumKey":44,"classKey":359,"orderKey":732,"familyKey":9703,"genusKey":2435098,"speciesKey":2435099,"parent":"Puma
+        concolor","parentKey":2435099,"scientificName":"Puma concolor bangsi (Merriam,
+        1901)","canonicalName":"Puma concolor bangsi","rank":"SUBSPECIES","status":"SYNONYM","higherClassificationMap":{"1":"Animalia","44":"Chordata","359":"Mammalia","732":"Carnivora","9703":"Felidae","2435098":"Puma","2435099":"Puma
+        concolor"},"synonym":true,"class":"Mammalia"},{"key":8860878,"kingdom":"Animalia","phylum":"Chordata","order":"Carnivora","family":"Felidae","genus":"Puma","species":"Puma
+        concolor","kingdomKey":1,"phylumKey":44,"classKey":359,"orderKey":732,"familyKey":9703,"genusKey":2435098,"speciesKey":2435099,"parent":"Puma
+        concolor","parentKey":2435099,"scientificName":"Puma concolor capricornensis
+        (Goldman, 1946)","canonicalName":"Puma concolor capricornensis","rank":"SUBSPECIES","status":"SYNONYM","higherClassificationMap":{"1":"Animalia","44":"Chordata","359":"Mammalia","732":"Carnivora","9703":"Felidae","2435098":"Puma","2435099":"Puma
+        concolor"},"synonym":true,"class":"Mammalia"},{"key":6164618,"kingdom":"Animalia","phylum":"Chordata","order":"Carnivora","family":"Felidae","genus":"Puma","species":"Puma
+        concolor","kingdomKey":1,"phylumKey":44,"classKey":359,"orderKey":732,"familyKey":9703,"genusKey":2435098,"speciesKey":2435099,"parent":"Puma
+        concolor","parentKey":2435099,"scientificName":"Puma concolor browni (Merriam,
+        1903)","canonicalName":"Puma concolor browni","rank":"SUBSPECIES","status":"SYNONYM","higherClassificationMap":{"1":"Animalia","44":"Chordata","359":"Mammalia","732":"Carnivora","9703":"Felidae","2435098":"Puma","2435099":"Puma
+        concolor"},"synonym":true,"class":"Mammalia"},{"key":8951716,"kingdom":"Animalia","phylum":"Chordata","order":"Carnivora","family":"Felidae","genus":"Puma","species":"Puma
+        concolor","kingdomKey":1,"phylumKey":44,"classKey":359,"orderKey":732,"familyKey":9703,"genusKey":2435098,"speciesKey":2435099,"parent":"Puma
+        concolor","parentKey":2435099,"scientificName":"Puma concolor borbensis (Nelson
+        & Goldman, 1933)","canonicalName":"Puma concolor borbensis","rank":"SUBSPECIES","status":"SYNONYM","higherClassificationMap":{"1":"Animalia","44":"Chordata","359":"Mammalia","732":"Carnivora","9703":"Felidae","2435098":"Puma","2435099":"Puma
+        concolor"},"synonym":true,"class":"Mammalia"},{"key":7193927,"kingdom":"Animalia","phylum":"Chordata","order":"Carnivora","family":"Felidae","genus":"Puma","species":"Puma
+        concolor","kingdomKey":1,"phylumKey":44,"classKey":359,"orderKey":732,"familyKey":9703,"genusKey":2435098,"speciesKey":2435099,"parent":"Puma
+        concolor","parentKey":2435099,"scientificName":"Puma concolor concolor","canonicalName":"Puma
+        concolor concolor","rank":"SUBSPECIES","status":"ACCEPTED","higherClassificationMap":{"1":"Animalia","44":"Chordata","359":"Mammalia","732":"Carnivora","9703":"Felidae","2435098":"Puma","2435099":"Puma
+        concolor"},"synonym":false,"class":"Mammalia"},{"key":6164604,"kingdom":"Animalia","phylum":"Chordata","order":"Carnivora","family":"Felidae","genus":"Puma","species":"Puma
+        concolor","kingdomKey":1,"phylumKey":44,"classKey":359,"orderKey":732,"familyKey":9703,"genusKey":2435098,"speciesKey":2435099,"parent":"Puma
+        concolor","parentKey":2435099,"scientificName":"Puma concolor stanleyana (Goldman,
+        1938)","canonicalName":"Puma concolor stanleyana","rank":"SUBSPECIES","status":"SYNONYM","higherClassificationMap":{"1":"Animalia","44":"Chordata","359":"Mammalia","732":"Carnivora","9703":"Felidae","2435098":"Puma","2435099":"Puma
+        concolor"},"synonym":true,"class":"Mammalia"},{"key":6164610,"kingdom":"Animalia","phylum":"Chordata","order":"Carnivora","family":"Felidae","genus":"Puma","species":"Puma
+        concolor","kingdomKey":1,"phylumKey":44,"classKey":359,"orderKey":732,"familyKey":9703,"genusKey":2435098,"speciesKey":2435099,"parent":"Puma
+        concolor","parentKey":2435099,"scientificName":"Puma concolor hippolestes
+        (Merriam, 1897)","canonicalName":"Puma concolor hippolestes","rank":"SUBSPECIES","status":"SYNONYM","higherClassificationMap":{"1":"Animalia","44":"Chordata","359":"Mammalia","732":"Carnivora","9703":"Felidae","2435098":"Puma","2435099":"Puma
+        concolor"},"synonym":true,"class":"Mammalia"},{"key":6164620,"kingdom":"Animalia","phylum":"Chordata","order":"Carnivora","family":"Felidae","genus":"Puma","species":"Puma
+        concolor","kingdomKey":1,"phylumKey":44,"classKey":359,"orderKey":732,"familyKey":9703,"genusKey":2435098,"speciesKey":2435099,"parent":"Puma
+        concolor","parentKey":2435099,"scientificName":"Puma concolor cougar (Kerr,
+        1792)","canonicalName":"Puma concolor cougar","rank":"SUBSPECIES","status":"SYNONYM","higherClassificationMap":{"1":"Animalia","44":"Chordata","359":"Mammalia","732":"Carnivora","9703":"Felidae","2435098":"Puma","2435099":"Puma
+        concolor"},"synonym":true,"class":"Mammalia"},{"key":9164058,"kingdom":"Animalia","phylum":"Chordata","order":"Carnivora","family":"Felidae","genus":"Puma","species":"Puma
+        concolor","kingdomKey":1,"phylumKey":44,"classKey":359,"orderKey":732,"familyKey":9703,"genusKey":2435098,"speciesKey":2435099,"parent":"Puma
+        concolor","parentKey":2435099,"scientificName":"Puma concolor osgoodi (Nelson
+        & Goldman, 1929)","canonicalName":"Puma concolor osgoodi","rank":"SUBSPECIES","status":"SYNONYM","higherClassificationMap":{"1":"Animalia","44":"Chordata","359":"Mammalia","732":"Carnivora","9703":"Felidae","2435098":"Puma","2435099":"Puma
+        concolor"},"synonym":true,"class":"Mammalia"},{"key":8944801,"kingdom":"Animalia","phylum":"Chordata","order":"Carnivora","family":"Felidae","genus":"Puma","species":"Puma
+        concolor","kingdomKey":1,"phylumKey":44,"classKey":359,"orderKey":732,"familyKey":9703,"genusKey":2435098,"speciesKey":2435099,"parent":"Puma
+        concolor","parentKey":2435099,"scientificName":"Puma concolor acrocodia (Goldman,
+        1943)","canonicalName":"Puma concolor acrocodia","rank":"SUBSPECIES","status":"SYNONYM","higherClassificationMap":{"1":"Animalia","44":"Chordata","359":"Mammalia","732":"Carnivora","9703":"Felidae","2435098":"Puma","2435099":"Puma
+        concolor"},"synonym":true,"class":"Mammalia"},{"key":9104297,"kingdom":"Animalia","phylum":"Chordata","order":"Carnivora","family":"Felidae","genus":"Puma","species":"Puma
+        concolor","kingdomKey":1,"phylumKey":44,"classKey":359,"orderKey":732,"familyKey":9703,"genusKey":2435098,"speciesKey":2435099,"parent":"Puma
+        concolor","parentKey":2435099,"scientificName":"Puma concolor greeni (Nelson
+        & Goldman, 1931)","canonicalName":"Puma concolor greeni","rank":"SUBSPECIES","status":"SYNONYM","higherClassificationMap":{"1":"Animalia","44":"Chordata","359":"Mammalia","732":"Carnivora","9703":"Felidae","2435098":"Puma","2435099":"Puma
+        concolor"},"synonym":true,"class":"Mammalia"}]'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Methods:
+      - HEAD, GET, POST, DELETE, PUT, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Age:
+      - '0'
+      Cache-Control:
+      - public, max-age=3601
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '12487'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2020 19:44:59 GMT
+      Server:
+      - Jetty(9.3.z-SNAPSHOT)
+      Via:
+      - 1.1 varnish (Varnish/5.2)
+      X-Varnish:
+      - '520915845'
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
…ered parse wrapper. Also added corresponding unit tests

## Description

This will be my first of (hopefully many) additions to pytaxize. For my initial test commit, I have added a very basic wrapper over the GBIF suggestion API (see https://www.gbif.org/developer/species => /species/suggest), that is similar in style to the already existing "parse.py". I have also added the corresponding unit tests. Code was run through "black", as requested in the contributions guide.

The GBIF wrapper itself takes a partially completed, or malformed name, and outputs an "autocompletion" of up to 20 possible taxa for the input name.

Should this be merged, I will follow up with an addition of GBIF to the docs.

## Related Issue

## Example

from pytaxize import gbif
response = gbif.suggest(
        name='puma con',
        as_dataframe=False
)
=> [{'scientificName':'puma concolor'},{...}]