### PR TITLE
Add delay to respect ncbi entrez api rate limit

### DIFF
--- a/pytaxize/refactor.py
+++ b/pytaxize/refactor.py
@@ -1,6 +1,6 @@
 import requests
 from lxml import etree
-
+import time
 
 class Refactor:
     def __init__(self, url, payload={}, request="get"):
@@ -20,6 +20,12 @@ class Refactor:
             out.raise_for_status()
             xmlparser = etree.XMLParser()
             tt = etree.fromstring(out.content, xmlparser)
+            try:
+                # If entrez api 'X-RateLimit-Remaining' header is 1 or below, pause for a second to allow rate limit to reset
+                if (int(out.headers['X-RateLimit-Remaining'])<=1):
+                    time.sleep(1)
+            except:
+                pass 
             return tt
         else:
             out = requests.post(self.url, params=self.payload, **kwargs)


### PR DESCRIPTION
## Description

Add 1 second delay within the Refactor.xml() function when the ncbi/entrez api returns a header ['X-RateLimit-Remaining'] <=1


## Related Issue
Refer to issue  #68

